### PR TITLE
feat(ai): support extensible AI providers (OpenAI default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Powered by [Iconify](https://iconify.design/)
 - Collections tab
 - Icon Inline Renderer component
 - Limit Collections option
-- AI-powered icon suggestions based on natural language prompts
+- AI-powered icon suggestions based on natural language prompts (OpenAI by default, extensible for other providers)
 
 <br /><br />
 
@@ -193,7 +193,7 @@ This is the main configuration of the plugin. The available options are:
   // Optional flag for storing the icons as an inline svg by default
   storeInlineSvg?: string
 
-  // AI-powered icon suggestion configuration
+  // AI-powered icon suggestion configuration (OpenAI by default)
   ai?: {
     // Custom secrets namespace for sharing AI configurations across projects
     secretsNamespace?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/openai": "1.3.23",
+        "@ai-sdk/openai": "1.3.24",
         "@iconify/react": "4.1.1",
         "@iconify/utils": "2.1.9",
         "@sanity/incompatible-plugin": "1.0.5",
@@ -293,9 +293,9 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.23.tgz",
-      "integrity": "sha512-86U7rFp8yacUAOE/Jz8WbGcwMCqWvjK33wk5DXkfnAOEn3mx2r7tNSJdjukQFZbAK97VMXGPPHxF+aEARDXRXQ==",
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "1.1.3",
@@ -29251,9 +29251,9 @@
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
     },
     "@ai-sdk/openai": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.23.tgz",
-      "integrity": "sha512-86U7rFp8yacUAOE/Jz8WbGcwMCqWvjK33wk5DXkfnAOEn3mx2r7tNSJdjukQFZbAK97VMXGPPHxF+aEARDXRXQ==",
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
       "requires": {
         "@ai-sdk/provider": "1.1.3",
         "@ai-sdk/provider-utils": "2.2.8"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@ai-sdk/openai": "1.3.23",
+    "@ai-sdk/openai": "1.3.24",
     "@iconify/react": "4.1.1",
     "@iconify/utils": "2.1.9",
     "@sanity/incompatible-plugin": "1.0.5",

--- a/src/config/defaultAIProviders.ts
+++ b/src/config/defaultAIProviders.ts
@@ -6,9 +6,8 @@
  */
 
 import { createOpenAI } from '@ai-sdk/openai'
-import { Provider } from 'ai'
 
-import { AIProvider } from '../types/ai-config'
+import { FlexibleAIProvider } from '../types/ai-config'
 
 /**
  * Default AI provider configurations
@@ -16,7 +15,7 @@ import { AIProvider } from '../types/ai-config'
  * These providers are available by default and can be extended or overridden
  * by consuming projects through plugin configuration.
  */
-export const defaultAIProviders: readonly AIProvider[] = [
+export const defaultAIProviders: readonly FlexibleAIProvider[] = [
   {
     name: 'OpenAI',
     keyName: 'openaiKey',
@@ -24,19 +23,15 @@ export const defaultAIProviders: readonly AIProvider[] = [
     models: [
       {
         type: 'language',
-        modelName: 'gpt-4o',
+        modelName: 'gpt-5',
       },
       {
         type: 'language',
-        modelName: 'gpt-4o-mini',
+        modelName: 'gpt-5-mini',
       },
       {
         type: 'language',
-        modelName: 'gpt-4-turbo',
-      },
-      {
-        type: 'language',
-        modelName: 'gpt-4',
+        modelName: 'gpt-5-nano',
       },
       {
         type: 'language',
@@ -52,32 +47,19 @@ export const defaultAIProviders: readonly AIProvider[] = [
       },
       {
         type: 'language',
-        modelName: 'gpt-4.5-preview',
+        modelName: 'gpt-4o',
       },
       {
         type: 'language',
         modelName: 'o1',
       },
-      {
-        type: 'language',
-        modelName: 'o3-mini',
-      },
-      {
-        type: 'language',
-        modelName: 'o4-mini',
-      },
     ],
     createInstance: (apiKey: string) =>
       createOpenAI({
         apiKey,
-        /**
-         * OpenAI compatibility mode. Should be set to `strict` when using the OpenAI API,
-         * and `compatible` when using 3rd party providers.
-         */
-        compatibility: 'strict', // OpenAI compatibility mode
-      }) as Provider,
+      }),
   },
-] as const satisfies readonly AIProvider[]
+] as const satisfies readonly FlexibleAIProvider[]
 
 /**
  * Default model selection for icon suggestions
@@ -97,7 +79,7 @@ export const DEFAULT_AI_SECRETS_NAMESPACE = 'sanity-plugin-inline-icon-manager-a
 /**
  * Get default provider by key name
  */
-export function getDefaultProvider(keyName: string): AIProvider | undefined {
+export function getDefaultProvider(keyName: string): FlexibleAIProvider | undefined {
   return defaultAIProviders.find((provider) => provider.keyName === keyName)
 }
 
@@ -118,7 +100,7 @@ export function isValidDefaultModel(modelName: string): boolean {
 /**
  * Get provider that contains a specific model
  */
-export function getProviderForModel(modelName: string): AIProvider | undefined {
+export function getProviderForModel(modelName: string): FlexibleAIProvider | undefined {
   return defaultAIProviders.find((provider) =>
     provider.models.some((model) => model.modelName === modelName),
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export { mediaPreview } from './plugin/mediaPreview'
 export { IconManager } from './plugin/plugin'
 
 // export some ai types
-export { type AIProvider } from './types/ai-config'
+export { type AIProvider, type FlexibleAIProvider, type ProviderType } from './types/ai-config'

--- a/src/services/ai-config-resolver.ts
+++ b/src/services/ai-config-resolver.ts
@@ -10,7 +10,7 @@ import {
   defaultAIProviders,
   defaultModelChoice,
 } from '../config/defaultAIProviders'
-import { AIModelChoiceType, AIPluginConfig, AIProvider } from '../types/ai-config'
+import { AIModelChoiceType, AIPluginConfig, FlexibleAIProvider } from '../types/ai-config'
 import { AIInlineIconManagerConfig } from '../types/ai-plugin-config'
 
 /**
@@ -18,7 +18,7 @@ import { AIInlineIconManagerConfig } from '../types/ai-plugin-config'
  */
 export interface ResolvedAIConfig {
   /** Merged provider configurations */
-  providers: AIProvider[]
+  providers: FlexibleAIProvider[]
   /** Resolved secrets namespace */
   secretsNamespace: string
   /** Resolved default model choice */
@@ -68,8 +68,8 @@ export function resolveAIConfig(pluginConfig?: AIInlineIconManagerConfig): Resol
 function resolveProviders(
   aiConfig: AIPluginConfig | undefined,
   result: ResolvedAIConfig,
-): AIProvider[] {
-  const providers: AIProvider[] = []
+): FlexibleAIProvider[] {
+  const providers: FlexibleAIProvider[] = []
   const providerNames = new Set<string>()
   const keyNames = new Set<string>()
 
@@ -249,23 +249,27 @@ function validateProvider(provider: unknown): ProviderValidation {
  * Get provider by key name from resolved configuration
  */
 export function getProviderByKeyName(
-  providers: AIProvider[],
+  providers: FlexibleAIProvider[],
   keyName: string,
-): AIProvider | undefined {
+): FlexibleAIProvider | undefined {
   return providers.find((provider) => provider.keyName === keyName)
 }
 
 /**
  * Get all model names from resolved providers
  */
-export function getAllModelNames(providers: AIProvider[]): string[] {
+export function getAllModelNames(providers: FlexibleAIProvider[]): string[] {
   return providers.flatMap((provider) => provider.models.map((model) => model.modelName))
 }
 
 /**
  * Check if a model exists in the resolved providers
  */
-export function isValidModel(providers: AIProvider[], modelName: string, keyName: string): boolean {
+export function isValidModel(
+  providers: FlexibleAIProvider[],
+  modelName: string,
+  keyName: string,
+): boolean {
   const provider = getProviderByKeyName(providers, keyName)
   if (!provider) return false
 


### PR DESCRIPTION
- Introduce generic provider typing and `FlexibleAIProvider` alias
- Replace concrete `AIProvider` usage across resolver, registry, and config
- Update default OpenAI models and provider factory usage
- Export additional types from `src/index.ts`
- Update docs/README to clarify OpenAI is included by default and architecture is extensible
- Bump dependency `@ai-sdk/openai` to 1.3.24
- Maintain backward compatibility with existing OpenAI-only setups